### PR TITLE
fix: delete logic

### DIFF
--- a/internal/controllers/workflows/workflows.go
+++ b/internal/controllers/workflows/workflows.go
@@ -101,7 +101,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (reconciler
 	}
 
 	got := ptr.Deref(cr.Status.Digest, "")
-	if len(got) == 0 && meta.WasDeleted(cr) {
+	if len(got) == 0 && meta.WasDeleted(cr) && cr.Status.GetCondition(rtv1.TypeReady).Reason == rtv1.ReasonDeleting {
 		return reconciler.ExternalObservation{
 			ResourceExists:   false,
 			ResourceUpToDate: true,
@@ -212,6 +212,7 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 		return err
 	}
 
+	cr.Status.SetConditions(rtv1.Deleting())
 	cr.Status.Digest = ptr.To("")
 
 	return e.kube.Status().Update(ctx, cr)

--- a/internal/workflows/workflows.go
+++ b/internal/workflows/workflows.go
@@ -3,6 +3,7 @@ package workflows
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/krateoplatformops/installer/apis/workflows/v1alpha1"
 	"github.com/krateoplatformops/installer/internal/cache"
@@ -98,6 +99,10 @@ func (wf *Workflow) Op(op steps.Op) {
 
 func (wf *Workflow) Run(ctx context.Context, spec *v1alpha1.WorkflowSpec, skip func(*v1alpha1.Step) bool) (results []StepResult) {
 	results = make([]StepResult, len(spec.Steps))
+
+	if wf.op == steps.Delete {
+		slices.Reverse(spec.Steps)
+	}
 
 	for i, x := range spec.Steps {
 		if skip(x) {


### PR DESCRIPTION
> - Delete fails when an error is retrieved in the steps during install, deleting the CR without uninstalling releases

Solved

> - Delete is wrong implemented, the steps list should be evaluated with a bottom up logic

Solved